### PR TITLE
change fixed width to percentage on sponsors articles

### DIFF
--- a/src/components/sponsors.css
+++ b/src/components/sponsors.css
@@ -16,10 +16,14 @@
   padding: 6%;
 }
 
+.sponsors-panel .sponsor {
+  max-width:30%
+}
+
 .premier-sponsors-panel img {
   max-width: 100%;
 }
 
 .sponsors-panel img {
-  max-width: 300px;
+  max-width: 100%;
 }


### PR DESCRIPTION
The width on the sponsor's images was causing the site to have some scrolling issues and weird icon placement in mobile. changed the article to have a percentage width of 30% to allow even distribution without sacrificing mobile.